### PR TITLE
Wrap each migration into its own transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ shift({
     before: ({ migration_id, name }) => {
         console.log('Migrating', migration_id, name);
     },
+    transactionPerEachMigration: true, // defaults to false
 })
     .then(() => console.log('All good'))
     .catch((err) => {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ export default async function({
   sql,
   path = join(process.cwd(), 'migrations'),
   before = null,
-  after = null
+  after = null,
+  transactionPerEachMigration = false
 }) {
   const migrations = fs.readdirSync(path)
     .filter(x => fs.statSync(join(path, x)).isDirectory() && x.match(/^[0-9]{5}_/))
@@ -28,17 +29,27 @@ export default async function({
   const current = await getCurrentMigration()
   const needed = migrations.slice(current ? current.id : 0)
 
-  return sql.begin(next)
+  return transactionPerEachMigration ? next(sql) : sql.begin(next)
 
   async function next(sql) {
     const current = needed.shift()
     if (!current)
       return
 
+    if (transactionPerEachMigration) {
+      await sql.begin(async (sql) => {
+        await step(sql, current);
+      })
+    } else {
+      await step(sql, current);
+    }
+    await next(sql)
+  }
+
+  async function step(sql, current) {
     before && before(current)
     await run(sql, current)
     after && after(current)
-    await next(sql)
   }
 
   async function run(sql, {


### PR DESCRIPTION
Hi!

I appreciate postgres-shift a lot! It's a wonderful, small, single purpose library. Thanks for creating it!

I come here with a suggestion to wrap each migration into its own transaction.

I grew up in Ruby on Rails universe and their transactions do this. As do the transactions in Ecto, Elixir's ORM.

I learned why it might be a good idea this week. I was extending a postgres Enum and then creating backfill records that used the newly created value. Instinctively I did that in separate migrations.

I didn't notice any issues in development because I ran each migration as I was writing it. Only once I shipped both migration in one PR I learned on our staging environment that one cannot create records referencing enum values added in the same transaction.

So please let me know if you'd consider adding this and releasing an updated version.

All the best,
Bartek
