### PR TITLE
Allow the usage of files instead of directories in migrations directory

### DIFF
--- a/tests/migrations/00004_create.sql
+++ b/tests/migrations/00004_create.sql
@@ -1,0 +1,4 @@
+create table test (
+  a text,
+  b int
+)

--- a/tests/migrations/00005_update.js
+++ b/tests/migrations/00005_update.js
@@ -1,0 +1,9 @@
+export default async function(sql) {
+  await sql`
+    alter table test add column c timestamp with time zone
+  `
+
+  await sql`
+    insert into test (a, b, c) values ('hello', 9, ${ new Date() })
+  `
+}

--- a/tests/migrations/00006_delete.sql
+++ b/tests/migrations/00006_delete.sql
@@ -1,0 +1,1 @@
+drop table test;


### PR DESCRIPTION
This avoids the need to create an index.(js|sql) and the directory with the name for each migration.

Fixes #4