### PR TITLE
Fix dynamic import of JS file on Deno

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ export default async function({
   }) {
     fs.existsSync(join(path, 'index.sql')) && !fs.existsSync(join(path, 'index.js'))
       ? await sql.file(join(path, 'index.sql'))
-      : await import(join(path, 'index.js')).then(x => x.default(sql)) // eslint-disable-line
+      : await import(join(process.cwd(), path, 'index.js')).then(x => x.default(sql)) // eslint-disable-line
 
     await sql`
       insert into migrations (


### PR DESCRIPTION
I use `postgres-shift` in a Deno project and even in Node compatibility mode it expects an absolute file in dynamic imports. The current implementation crashes when I use JS migrations.

That's why I suggest to use `process.cwd()` in the call to `path.join()`. I tested it on my side and it fixes the problem. If you are okay with that I would be glad you merged it.